### PR TITLE
Parse headers via regexp 

### DIFF
--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -9,7 +9,8 @@ var
 	 */
 	REGEXP_CONTENT_TYPE = /^([^\t \/]+)\/([^\t ;]+)(.*)$/,
 	REGEXP_CONTENT_TRANSFER_ENCODING = /^([a-zA-Z0-9\-_]+)$/,
-	REGEXP_PARAM = /^[ \t]*([^\t =]+)[ \t]*=[ \t]*([^"\t =]+|"([^"]*)")[ \t]*$/;
+	REGEXP_PARAM_KEY = /;[ \t|]*([^\t =]+)[ \t]*=[ \t]*/g,
+	REGEXP_PARAM_VALUES = /[ \t]*([^"\t =]+|"([^"]*)")[ \t]*$/;
 
 
 grammar.headerRules = {
@@ -113,20 +114,14 @@ function parseParams(rawParams) {
 	if (rawParams === '' || rawParams === undefined || rawParams === null) {
 		return params;
 	}
+	var splittedParams = rawParams.split(REGEXP_PARAM_KEY);
 
-	splittedParams = rawParams.split(';');
-	if (splittedParams.length === 0) {
-		return undefined;
-	}
-
-	for (i = 1, len = splittedParams.length; i < len; i++) {
-		paramMatch = splittedParams[i].match(REGEXP_PARAM);
-		if (!paramMatch) {
-			return undefined;
-		}
-
-		params[paramMatch[1].toLowerCase()] = paramMatch[3] || paramMatch[2];
-	}
-
-	return params;
+	return splittedParams.slice(1)
+		.reduce(function (acc, key, i, list) {
+			if (!(i%2)) {
+				var values = (list[i + 1] || '').match(REGEXP_PARAM_VALUES) || [];
+				acc[key.toLowerCase()] = values[2] || values[1];
+			}
+			return acc;
+		}, Object.create(null));
 }

--- a/test/test_message.js
+++ b/test/test_message.js
@@ -61,4 +61,16 @@ describe('Message', function () {
 		}));
 	});
 
+	it('must parse header custom with ;', function () {
+		const contentType = 'image/png; filename="Fleshing out a sketch of a bird for a friend! - ;.png"; name="Fleshing out a sketch of a bird for a friend! - ;.png"';
+		const name = 'Fleshing out a sketch of a bird for a friend! - ;.png';
+		var msg = mimemessage.factory({
+				contentType
+		});
+
+		expect(msg.contentType().params).to.eql({
+			name, filename: name
+		});
+	});
+
 });


### PR DESCRIPTION
Hey, 

I've found this issue using the lib:
```
console.js:35 Error: parseHeaderValue() failed for image/png; filename="Fleshing out a sketch of a bird for a friend! - ;.png"; name="Fleshing out a sketch of a bird for a friend! - ;.png"
    at u (parse.js:214)
```

The parsing of headers was done via `;` and as it's inside the name here it creates a bug.
So instead of using this `;` I replaced it via something from REGEXP_PARAM.
A test will cover this use case now :) 